### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/main.py
+++ b/main.py
@@ -212,7 +212,9 @@ def main(args):
     if not source_url:
         raise ValueError("No URL provided. Please specify a YouTube or EarthCam URL using --url.")
     is_youtube_url = "youtube.com" in source_url or "youtu.be" in source_url
-    is_earthcam_url = "earthcam.com" in source_url
+    from urllib.parse import urlparse
+    parsed_url = urlparse(source_url)
+    is_earthcam_url = parsed_url.hostname and parsed_url.hostname.endswith(".earthcam.com")
 
     cv_processor_instance = None
     if not args.no_cv:


### PR DESCRIPTION
Potential fix for [https://github.com/jacklatrobe/Generic-CV-Streamer/security/code-scanning/2](https://github.com/jacklatrobe/Generic-CV-Streamer/security/code-scanning/2)

To fix the issue, the code should parse the `source_url` using Python's `urllib.parse` module and validate the hostname explicitly. This ensures that the check is performed on the actual domain of the URL, not on arbitrary substrings. Specifically, the `urlparse` function can be used to extract the hostname, and the check can then verify if the hostname matches `earthcam.com` or its subdomains (e.g., `*.earthcam.com`).

The changes will involve:
1. Importing the `urlparse` function from `urllib.parse`.
2. Replacing the substring check `"earthcam.com" in source_url` with a parsed hostname check using `urlparse`.
3. Ensuring the hostname ends with `.earthcam.com` to allow subdomains.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
